### PR TITLE
feat: add markdown converter library with support for HTML, DOCX, PDF and PNG formats

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,35 @@
+name: Publish Package to GitHub Packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@blessing'
+
+      - name: Install dependencies
+        run: cd markdown-converter-lib && npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build
+        run: cd markdown-converter-lib && npm run build
+
+      - name: Publish
+        run: cd markdown-converter-lib && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/markdown-converter-lib/LICENSE
+++ b/markdown-converter-lib/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/markdown-converter-lib/README.md
+++ b/markdown-converter-lib/README.md
@@ -1,0 +1,62 @@
+# Markdown Converter Library
+
+A powerful library to convert markdown content to various formats including HTML, PDF, DOCX, and PNG.
+
+## Features
+
+- 📝 Convert markdown to HTML
+- 📄 Convert markdown to DOCX with proper formatting
+- 📑 Convert markdown to PDF with proper page breaks
+- 🖼️ Convert markdown preview to PNG
+
+## Installation
+
+```bash
+npm install markdown-converter-lib
+```
+
+## Usage
+
+```typescript
+import { MarkdownConverter } from "markdown-converter-lib";
+
+const converter = new MarkdownConverter();
+
+// Convert to HTML
+const html = converter.toHTML("# Hello World");
+
+// Convert to DOCX
+const docxBlob = await converter.toDOCX("# Hello World");
+const docxUrl = URL.createObjectURL(docxBlob);
+// Use the URL to download the file
+
+// Convert to PDF
+const pdfBlob = await converter.toPDF("# Hello World");
+const pdfUrl = URL.createObjectURL(pdfBlob);
+// Use the URL to download the file
+
+// Convert preview element to PNG
+const previewElement = document.getElementById("markdown-preview");
+const pngDataUrl = await converter.toPNG(previewElement);
+// Use the data URL for the PNG image
+```
+
+## Supported Markdown Features
+
+- Headers (H1-H6)
+- Bold and italic text
+- Lists (ordered and unordered)
+- Code blocks with syntax highlighting
+- Blockquotes
+- Horizontal rules
+- Links
+- Images
+
+## Requirements
+
+- Node.js >= 18.0.0
+- Modern browser environment for PNG conversion
+
+## License
+
+MIT License - see LICENSE file for details

--- a/markdown-converter-lib/package-lock.json
+++ b/markdown-converter-lib/package-lock.json
@@ -1,0 +1,622 @@
+{
+	"name": "@blessing/markdown-converter-lib",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@blessing/markdown-converter-lib",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"docx": "^9.4.1",
+				"html2canvas": "^1.4.1",
+				"jspdf": "^3.0.1",
+				"mammoth": "^1.9.0",
+				"marked": "^15.0.11",
+				"pdf-lib": "^1.17.1"
+			},
+			"devDependencies": {
+				"@types/node": "^22.15.2",
+				"typescript": "~5.7.2"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@pdf-lib/standard-fonts": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+			"integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^1.0.6"
+			}
+		},
+		"node_modules/@pdf-lib/upng": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+			"integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^1.0.10"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "22.15.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+			"integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/raf": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+			"integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.8.10",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+			"integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"license": "(MIT OR Apache-2.0)",
+			"bin": {
+				"atob": "bin/atob.js"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/base64-arraybuffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bluebird": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+			"license": "MIT"
+		},
+		"node_modules/btoa": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+			"integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+			"license": "(MIT OR Apache-2.0)",
+			"bin": {
+				"btoa": "bin/btoa.js"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/canvg": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+			"integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"@types/raf": "^3.4.0",
+				"core-js": "^3.8.3",
+				"raf": "^3.4.1",
+				"regenerator-runtime": "^0.13.7",
+				"rgbcolor": "^1.0.1",
+				"stackblur-canvas": "^2.0.0",
+				"svg-pathdata": "^6.0.3"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/core-js": {
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+			"integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"license": "MIT"
+		},
+		"node_modules/css-line-break": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+			"license": "MIT",
+			"dependencies": {
+				"utrie": "^1.0.2"
+			}
+		},
+		"node_modules/dingbat-to-unicode": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+			"integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/docx": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/docx/-/docx-9.5.0.tgz",
+			"integrity": "sha512-WZggg9vVujFcTyyzfIVBBIxlCk51QvhLWl87wtI2zuBdz8C8C0mpRhEVwA2DZd7dXyY0AVejcEVDT9vn7Xm9FA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^22.7.5",
+				"hash.js": "^1.1.7",
+				"jszip": "^3.10.1",
+				"nanoid": "^5.1.3",
+				"xml": "^1.0.1",
+				"xml-js": "^1.6.8"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+			"integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optional": true,
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
+		},
+		"node_modules/duck": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+			"integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+			"license": "BSD",
+			"dependencies": {
+				"underscore": "^1.13.1"
+			}
+		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"license": "MIT"
+		},
+		"node_modules/hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/html2canvas": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+			"license": "MIT",
+			"dependencies": {
+				"css-line-break": "^2.1.0",
+				"text-segmentation": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"license": "MIT"
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"license": "MIT"
+		},
+		"node_modules/jspdf": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+			"integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.26.7",
+				"atob": "^2.1.2",
+				"btoa": "^1.2.1",
+				"fflate": "^0.8.1"
+			},
+			"optionalDependencies": {
+				"canvg": "^3.0.11",
+				"core-js": "^3.6.0",
+				"dompurify": "^3.2.4",
+				"html2canvas": "^1.0.0-rc.5"
+			}
+		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"node_modules/lop": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+			"integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"duck": "^0.1.12",
+				"option": "~0.2.1",
+				"underscore": "^1.13.1"
+			}
+		},
+		"node_modules/mammoth": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.9.1.tgz",
+			"integrity": "sha512-4S2v1eP4Yo4so0zGNicJKcP93su3wDPcUk+xvkjSG75nlNjSkDJu8BhWQ+e54BROM0HfA6nPzJn12S6bq2Ko6w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.8.6",
+				"argparse": "~1.0.3",
+				"base64-js": "^1.5.1",
+				"bluebird": "~3.4.0",
+				"dingbat-to-unicode": "^1.0.1",
+				"jszip": "^3.7.1",
+				"lop": "^0.4.2",
+				"path-is-absolute": "^1.0.0",
+				"underscore": "^1.13.1",
+				"xmlbuilder": "^10.0.0"
+			},
+			"bin": {
+				"mammoth": "bin/mammoth"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"license": "ISC"
+		},
+		"node_modules/nanoid": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+			"integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.js"
+			},
+			"engines": {
+				"node": "^18 || >=20"
+			}
+		},
+		"node_modules/option": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+			"integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pdf-lib": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+			"integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+			"license": "MIT",
+			"dependencies": {
+				"@pdf-lib/standard-fonts": "^1.0.0",
+				"@pdf-lib/upng": "^1.0.1",
+				"pako": "^1.0.11",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"license": "MIT"
+		},
+		"node_modules/raf": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"performance-now": "^2.1.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/rgbcolor": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+			"integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+			"license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.8.15"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+			"license": "ISC"
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+			"license": "MIT"
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/stackblur-canvas": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+			"integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.14"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/svg-pathdata": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+			"integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/text-segmentation": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+			"license": "MIT",
+			"dependencies": {
+				"utrie": "^1.0.2"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
+		},
+		"node_modules/typescript": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/underscore": {
+			"version": "1.13.7",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
+		},
+		"node_modules/utrie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+			"license": "MIT",
+			"dependencies": {
+				"base64-arraybuffer": "^1.0.2"
+			}
+		},
+		"node_modules/xml": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+			"integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+			"license": "MIT"
+		},
+		"node_modules/xml-js": {
+			"version": "1.6.11",
+			"resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+			"integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": "^1.2.4"
+			},
+			"bin": {
+				"xml-js": "bin/cli.js"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+			"integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		}
+	}
+}

--- a/markdown-converter-lib/package.json
+++ b/markdown-converter-lib/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@blessing/markdown-converter-lib",
+	"version": "1.0.0",
+	"description": "Convert markdown to various formats including HTML, PDF, DOCX, and PNG",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"type": "module",
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/blessing/markdown-converter.git"
+	},
+	"scripts": {
+		"build": "tsc",
+		"prepublishOnly": "npm run build"
+	},
+	"keywords": [
+		"markdown",
+		"converter",
+		"docx",
+		"pdf",
+		"html",
+		"png",
+		"export"
+	],
+	"author": "",
+	"license": "MIT",
+	"dependencies": {
+		"docx": "^9.4.1",
+		"html2canvas": "^1.4.1",
+		"jspdf": "^3.0.1",
+		"mammoth": "^1.9.0",
+		"marked": "^15.0.11",
+		"pdf-lib": "^1.17.1"
+	},
+	"devDependencies": {
+		"@types/node": "^22.15.2",
+		"typescript": "~5.7.2"
+	},
+	"peerDependencies": {},
+	"files": [
+		"dist",
+		"LICENSE",
+		"README.md"
+	]
+}

--- a/markdown-converter-lib/src/ImageProcessor.ts
+++ b/markdown-converter-lib/src/ImageProcessor.ts
@@ -1,0 +1,57 @@
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
+
+export class ImageProcessor {
+	private createCaptureElement(sourceElement: HTMLElement): HTMLElement {
+		const tempDiv = document.createElement("div");
+		tempDiv.style.position = "absolute";
+		tempDiv.style.left = "-9999px";
+		tempDiv.style.top = "0";
+		tempDiv.innerHTML = sourceElement.innerHTML;
+		tempDiv.style.backgroundColor = "#ffffff";
+		tempDiv.style.color = "#000000";
+		tempDiv.style.padding = "20px";
+		tempDiv.style.width = sourceElement.offsetWidth + "px";
+
+		document.body.appendChild(tempDiv);
+
+		return tempDiv;
+	}
+
+	private async captureToCanvas(
+		element: HTMLElement
+	): Promise<HTMLCanvasElement> {
+		const captureElement = this.createCaptureElement(element);
+		try {
+			return await html2canvas(captureElement, {
+				useCORS: true,
+				backgroundColor: "#ffffff",
+				scale: 2,
+				logging: false,
+			});
+		} finally {
+			if (document.body.contains(captureElement)) {
+				document.body.removeChild(captureElement);
+			}
+		}
+	}
+
+	public async convertToPNG(element: HTMLElement): Promise<string> {
+		const canvas = await this.captureToCanvas(element);
+		return canvas.toDataURL("image/png");
+	}
+
+	public async convertToPDF(element: HTMLElement): Promise<Blob> {
+		const canvas = await this.captureToCanvas(element);
+		const imgData = canvas.toDataURL("image/png");
+
+		const pdf = new jsPDF();
+		const imgProps = pdf.getImageProperties(imgData);
+		const pdfWidth = pdf.internal.pageSize.getWidth();
+		const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+
+		pdf.addImage(imgData, "PNG", 0, 0, pdfWidth, pdfHeight);
+		const pdfBlob = pdf.output("blob");
+		return pdfBlob;
+	}
+}

--- a/markdown-converter-lib/src/MarkdownProcessor.ts
+++ b/markdown-converter-lib/src/MarkdownProcessor.ts
@@ -1,0 +1,167 @@
+import { Document, Packer, Paragraph, TextRun, BorderStyle } from "docx";
+import { marked } from "marked";
+
+type TokenType = {
+	type: string;
+	text?: string;
+	depth?: number;
+	items?: TokenType[];
+	tokens?: TokenType[];
+	raw?: string;
+};
+
+export class MarkdownProcessor {
+	private static readonly headingLevelMap = {
+		1: "Heading1",
+		2: "Heading2",
+		3: "Heading3",
+		4: "Heading4",
+		5: "Heading5",
+		6: "Heading6",
+	} as const;
+
+	private processInlineTokens(text: string): TextRun[] {
+		const inlineTokens = marked.lexer(text) as TokenType[];
+		return inlineTokens.map((token) => {
+			switch (token.type) {
+				case "strong":
+					return new TextRun({ text: token.text || "", bold: true });
+				case "em":
+					return new TextRun({ text: token.text || "", italics: true });
+				case "codespan":
+					return new TextRun({ text: token.text || "", font: "Courier New" });
+				default:
+					return new TextRun({ text: token.text || token.raw || "" });
+			}
+		});
+	}
+
+	private createHeadingParagraph(token: TokenType): Paragraph {
+		return new Paragraph({
+			children: this.processInlineTokens(token.text || ""),
+			heading:
+				MarkdownProcessor.headingLevelMap[
+					token.depth as keyof typeof MarkdownProcessor.headingLevelMap
+				],
+			spacing: { before: 240, after: 120 },
+		});
+	}
+
+	private createListItemParagraph(text: string): Paragraph {
+		return new Paragraph({
+			children: [
+				new TextRun({ text: "• " }),
+				...this.processInlineTokens(text),
+			],
+			indent: { left: 720 },
+			spacing: { before: 60, after: 60 },
+		});
+	}
+
+	private createCodeBlockParagraph(text: string): Paragraph {
+		return new Paragraph({
+			children: [
+				new TextRun({
+					text: text,
+					font: "Courier New",
+					size: 20,
+				}),
+			],
+			spacing: { before: 120, after: 120 },
+			indent: { left: 360 },
+			shading: { fill: "F2F2F2" },
+		});
+	}
+
+	private createBlockQuoteParagraph(text: string): Paragraph {
+		return new Paragraph({
+			children: this.processInlineTokens(text),
+			indent: { left: 360 },
+			spacing: { before: 120, after: 120 },
+			border: {
+				left: {
+					size: 4,
+					color: "#70B5F9",
+					space: 8,
+					style: BorderStyle.SINGLE,
+				},
+			},
+		});
+	}
+
+	private createHorizontalRuleParagraph(): Paragraph {
+		return new Paragraph({
+			text: "",
+			border: {
+				bottom: {
+					size: 1,
+					color: "#CCCCCC",
+					space: 8,
+					style: BorderStyle.SINGLE,
+				},
+			},
+			spacing: { before: 240, after: 240 },
+		});
+	}
+
+	public convertToDocxParagraphs(content: string): Paragraph[] {
+		const tokens = marked.lexer(content) as TokenType[];
+		const paragraphs: Paragraph[] = [];
+
+		for (const token of tokens) {
+			switch (token.type) {
+				case "heading":
+					paragraphs.push(this.createHeadingParagraph(token));
+					break;
+
+				case "paragraph":
+					paragraphs.push(
+						new Paragraph({
+							children: this.processInlineTokens(token.text || ""),
+							spacing: { before: 120, after: 120 },
+						})
+					);
+					break;
+
+				case "list":
+					(token.items || []).forEach((item) => {
+						paragraphs.push(this.createListItemParagraph(item.text || ""));
+					});
+					break;
+
+				case "code":
+					paragraphs.push(this.createCodeBlockParagraph(token.text || ""));
+					break;
+
+				case "blockquote":
+					if (token.tokens) {
+						token.tokens.forEach((quoteToken) => {
+							paragraphs.push(
+								this.createBlockQuoteParagraph(quoteToken.text || "")
+							);
+						});
+					}
+					break;
+
+				case "hr":
+					paragraphs.push(this.createHorizontalRuleParagraph());
+					break;
+			}
+		}
+
+		return paragraphs;
+	}
+
+	public async createDocument(content: string): Promise<Blob> {
+		const doc = new Document({
+			sections: [
+				{
+					properties: {},
+					children: this.convertToDocxParagraphs(content),
+				},
+			],
+		});
+
+		return await Packer.toBlob(doc);
+	}
+}

--- a/markdown-converter-lib/src/index.ts
+++ b/markdown-converter-lib/src/index.ts
@@ -1,0 +1,94 @@
+import { Document, Packer } from "docx";
+import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
+import mammoth from "mammoth";
+import { marked } from "marked";
+import { MarkdownProcessor } from "./MarkdownProcessor";
+import { ImageProcessor } from "./ImageProcessor";
+
+export class MarkdownConverter {
+	private markdownProcessor: MarkdownProcessor;
+	private imageProcessor: ImageProcessor;
+
+	constructor() {
+		this.markdownProcessor = new MarkdownProcessor();
+		this.imageProcessor = new ImageProcessor();
+	}
+
+	/**
+	 * Convert markdown to HTML
+	 */
+	public async toHTML(content: string): Promise<string> {
+		return await marked(content);
+	}
+
+	/**
+	 * Convert markdown to DOCX
+	 */
+	public async toDOCX(content: string): Promise<Blob> {
+		return await this.markdownProcessor.createDocument(content);
+	}
+
+	/**
+	 * Convert markdown to PDF
+	 */
+	public async toPDF(content: string): Promise<Blob> {
+		const doc = new Document({
+			sections: [
+				{
+					properties: {},
+					children: this.markdownProcessor.convertToDocxParagraphs(content),
+				},
+			],
+		});
+
+		const docBlob = await Packer.toBlob(doc);
+		return await this.convertDocxToPdf(docBlob);
+	}
+
+	/**
+	 * Convert markdown preview element to PNG
+	 */
+	public async toPNG(element: HTMLElement): Promise<string> {
+		return await this.imageProcessor.convertToPNG(element);
+	}
+
+	private async convertDocxToPdf(docBlob: Blob): Promise<Blob> {
+		const arrayBuffer = await docBlob.arrayBuffer();
+		const { value: html } = await mammoth.convertToHtml({ arrayBuffer });
+
+		const pdfDoc = await PDFDocument.create();
+		let currentPage = pdfDoc.addPage([612, 792]);
+		const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+		const cleanText = html
+			.replace(/<[^>]+>/g, "\n")
+			.replace(/&[^;]+;/g, "")
+			.trim();
+
+		const lines = cleanText.split("\n").filter((line) => line.trim());
+
+		let y = 750;
+		const fontSize = 12;
+		const lineHeight = fontSize * 1.2;
+
+		for (const line of lines) {
+			if (y < 50) {
+				y = 750;
+				currentPage = pdfDoc.addPage([612, 792]);
+			}
+
+			currentPage.drawText(line, {
+				x: 50,
+				y,
+				size: fontSize,
+				font,
+				color: rgb(0, 0, 0),
+			});
+
+			y -= lineHeight;
+		}
+
+		const pdfBytes = await pdfDoc.save();
+		return new Blob([pdfBytes], { type: "application/pdf" });
+	}
+}

--- a/markdown-converter-lib/tsconfig.json
+++ b/markdown-converter-lib/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"esModuleInterop": true,
+		"declaration": true,
+		"outDir": "./dist",
+		"strict": true,
+		"skipLibCheck": true,
+		"lib": ["ES2020", "DOM"]
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Add markdown converter library with support for HTML, DOCX, PDF and PNG formats
- Implemented MarkdownProcessor for converting markdown to DOCX paragraphs.
- Added ImageProcessor for capturing HTML elements as PNG and PDF.
- Created MarkdownConverter class to handle conversions between markdown and various formats.
- Configured TypeScript with strict settings and output directory.
- Included necessary dependencies for document generation and image processing.